### PR TITLE
add the contract name when submitting a new contract

### DIFF
--- a/src/main/java/org/adridadou/ethereum/BlockchainProxyTest.java
+++ b/src/main/java/org/adridadou/ethereum/BlockchainProxyTest.java
@@ -46,7 +46,7 @@ public class BlockchainProxyTest implements BlockchainProxy {
 
     @Override
     public CompletableFuture<EthAddress> publish(SoliditySource code, String contractName, EthAccount sender, Object... constructorArgs) {
-        return CompletableFuture.completedFuture(EthAddress.of(blockchain.submitNewContract(code.getSource(), constructorArgs).getAddress()));
+        return CompletableFuture.completedFuture(EthAddress.of(blockchain.submitNewContract(code.getSource(), contractName, constructorArgs).getAddress()));
     }
 
     @Override


### PR DESCRIPTION
When using the BlockchainProxyTest the contract name is not submitted. Which won't work when you have several contracts in a file.